### PR TITLE
Prompt when closing or quitting with unsaved changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ One further common problem is that `tmux` can change key combination behaviour, 
   * `CTRL+N`: Open a new file.
   * `CTRL+O`: Open an existing file.
   * `CTRL+S`: Saves the current file.
+  * `CTRL+Q`: Quit Vim.
   * `CTRL+G`: Goto line.
   * `ALT+;` or `ALT+c`: Vim's command prompt.
   * `ALT+o`: Replaces native `CTRL+O` to give one-off Normal Mode commands.
@@ -119,4 +120,3 @@ Lastly you can unmap a mapping using commands such as `nunmap`, `iunmap`, `sunma
   * In Neovim there seems to be a bug where only `SHIFT+TAB` and not `TAB` works for indenting during selection mode.
   * Mapping `<CTRL+M>` internally means mapping `<RETURN>`. This is a throwback to Vim's days as a pure terminal application.
   * `CTRL+BACKSPACE` internally represents `<CTRL+H>`, which can be annoying. Again this is a throwback to Vim's days as a pure terminal application.
-

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -320,6 +320,7 @@ function! novim_mode#ExitVim()
     endif
   else
     quitall
+  endif
 endfunction
 
 function! novim_mode#GotoLine()

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -247,8 +247,9 @@ function! s:SetWrappedTextNavigation()
     \org,
     \creole,
     \mediawiki
-  \} setlocal filetype=txt
+  \} setlocal filetype=markdown
   autocmd FileType \
+    \markdown,
     \rst,
     \asciidoc,
     \pod,

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -291,11 +291,17 @@ function! novim_mode#ClosePane()
     " Close any quickfix lists on screen.
     exe "cclose"
 
+    let l:check = execute(":ls")
     if s:CountListedBuffers() > 1
       " By default if the buffer is the only one on screen, closing it closes the
       " tab/window. So this little trick does a switch to the next buffer,
       " then closes the previous buffer.
       exe "bp\|bd #"
+    elseif l:check =~ "%a +"
+      let l:confirmed = confirm('There are unsaved changes. Close anyway?', "&Yes\n&No", 2)
+      if l:confirmed == 1
+        quit!
+      endif
     else
       quit
     endif
@@ -304,12 +310,15 @@ function! novim_mode#ClosePane()
   endif
 endfunction
 
-" TODO: Mention any unsaved buffers
 function! novim_mode#ExitVim()
-  let l:confirmed = confirm('Do you really want to quit Vim?', "&Yes\n&No", 2)
-  if l:confirmed == 1
-    quitall!
-  endif
+  let l:check = execute(":ls")
+  if l:check =~ "+"
+    let l:confirmed = confirm('There are unsaved changes. Quit anyway?', "&Yes\n&No", 2)
+    if l:confirmed == 1
+      quitall!
+    endif
+  else
+    quitall
 endfunction
 
 function! novim_mode#GotoLine()

--- a/doc/novim_mode.txt
+++ b/doc/novim_mode.txt
@@ -76,6 +76,7 @@ General editor shortcuts
   * `CTRL+N`: Open a new file.
   * `CTRL+O`: Open an existing file.
   * `CTRL+S`: Saves the current file.
+  * `CTRL+Q`: Quit Vim.
   * `CTRL+G`: Goto line.
   * `ALT+;` or `ALT+c`: Vim command prompt.
   * `ALT+o`: Replaces native `CTRL+O` to give one-off Normal Mode commands.


### PR DESCRIPTION
Trying to close a pane with unsaved changes with Ctrl+W currently throws an error. This fixes that, and instead prompts the user to either go back and save or quit anyway.

It also removes the "Are you sure you want to quit?" prompt when using Ctrl+Q when there are no unsaved changes.