### PR TITLE
[Not for merging]Fixes the terminal problem

### DIFF
--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -3,6 +3,7 @@
 function! s:IsEditableBuffer()
   if &buftype ==# 'terminal'
     return 0
+  endif
   if &buftype ==# 'nofile'
      \|| !&modifiable
      \|| &readonly

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -1,6 +1,8 @@
 " A fundamental question for this plugin is whether insertmode
 " is always relevant. This is where we try to get an answer.
 function! s:IsEditableBuffer()
+  if &buftype ==# 'terminal'
+    return 1
   if &buftype ==# 'nofile'
      \|| !&modifiable
      \|| &readonly

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -1,7 +1,7 @@
 " A fundamental question for this plugin is whether insertmode
 " is always relevant. This is where we try to get an answer.
 function! s:IsEditableBuffer()
-  if &buftype ==# 'nofile'
+  if &buftype ==# 'terminal'
     return 0
   if &buftype ==# 'nofile'
      \|| !&modifiable

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -1,15 +1,15 @@
 " A fundamental question for this plugin is whether insertmode
 " is always relevant. This is where we try to get an answer.
 function! s:IsEditableBuffer()
-  if &buftype ==# 'terminal'
-    return 0
-  endif
   if &buftype ==# 'nofile'
      \|| !&modifiable
      \|| &readonly
     return 0
   else
     return 1
+  endif
+  if &buftype ==# 'terminal'
+    return 0
   endif
 endfunction
 

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -5,11 +5,6 @@ function! s:IsEditableBuffer()
      \|| !&modifiable
      \|| &readonly
     return 0
-  else
-    return 1
-  endif
-  if &buftype ==# 'terminal'
-    return 0
   endif
 endfunction
 

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -2,9 +2,13 @@
 " is always relevant. This is where we try to get an answer.
 function! s:IsEditableBuffer()
   if &buftype ==# 'nofile'
+    return 0
+  if &buftype ==# 'nofile'
      \|| !&modifiable
      \|| &readonly
     return 0
+  else
+    return 1
   endif
 endfunction
 

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -1,14 +1,10 @@
 " A fundamental question for this plugin is whether insertmode
 " is always relevant. This is where we try to get an answer.
 function! s:IsEditableBuffer()
-  if &buftype ==# 'terminal'
-    return 1
   if &buftype ==# 'nofile'
      \|| !&modifiable
      \|| &readonly
     return 0
-  else
-    return 1
   endif
 endfunction
 


### PR DESCRIPTION
This is just for helping you to fix the issue it is not meant to be merged. I am not familiar with vim script so sadly couldn't fix the issue properly. I have just deleted some lines(please check them) and made plugin to always default to noinsertmode and this somehow fixes the terminal problem I mentioned here https://github.com/tombh/novim-mode/issues/9
But changing those lines should have much wider consequences(I have already seen some).
I have made some searches and from what I understand we have to do something like ```if &buftype ==# "terminal"``` and check if the buffer is terminal or not and then do something. Thanks I hope this helps.