### PR TITLE
Add tab navigation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ One further common problem is that `tmux` can change key combination behaviour, 
   * `ALT+;` or `ALT+c`: Vim's command prompt.
   * `ALT+o`: Replaces native `CTRL+O` to give one-off Normal Mode commands.
 
+#### Tab navigation
+  * `CTRL+T`: Open a new tab.
+  * `CTRL+SHIFT+T`: Cycle through open tabs.
+
 #### Pane controls
   * `ALT+ARROW`: Change pane/buffer focus.
   * `CTRL+W`: Closes current pane-like thing. Also closes associated quickfix and location panes.
@@ -98,6 +102,7 @@ call novim_mode#StartNoVimMode()
 Shortcuts are also grouped roughly under the headings described above, so you may be able to disable one of the following:
 ```vim
 let g:novim_mode_use_general_app_shortcuts = 1
+let g:novim_mode_use_tab_shortcuts = 1
 let g:novim_mode_use_pane_controls = 1
 let g:novim_mode_use_copypasting = 1
 let g:novim_mode_use_indenting = 1

--- a/autoload/novim_mode.vim
+++ b/autoload/novim_mode.vim
@@ -118,6 +118,19 @@ function! g:SetNoVimModeShortcuts()
     inoremap <silent> <PageUp> <C-O>:call novim_mode#PageUp()<CR>
   endif
 
+  " Open and cycle between tabs
+  if g:novim_mode_use_tab_shortcuts == 1
+    " Open a new tab
+    nnoremap <silent> <C-T> :tabnew<CR>
+    inoremap <silent> <C-T> <C-O>:tabnew<CR>
+    snoremap <silent> <C-T> <C-O>:tabnew<CR>
+    " Cycle through tabs
+    " I would prefer <C-Tab>, but can't use it due to technical limitations.
+    nnoremap <silent> <C-S-T> :tabnext<CR>
+    inoremap <silent> <C-S-T> <C-O>:tabnext<CR>
+    snoremap <silent> <C-S-T> <C-O>:tabnext<CR>
+  end
+
   " Move between splits, panes, windows, etc and close them
   if g:novim_mode_use_pane_controls == 1
     inoremap <silent> <M-Left>  <C-O><C-W><Left>

--- a/doc/novim_mode.txt
+++ b/doc/novim_mode.txt
@@ -81,6 +81,10 @@ General editor shortcuts
   * `ALT+;` or `ALT+c`: Vim command prompt.
   * `ALT+o`: Replaces native `CTRL+O` to give one-off Normal Mode commands.
 
+Tab navigation
+  * `CTRL+T`: Open a new tab.
+  * `CTRL+SHIFT+T`: Cycle through open tabs.
+
 Pane controls
   * `ALT+ARROW`: Change pane/buffer focus.
   * `CTRL+W`: Closes current pane-like thing. Also closes associated
@@ -146,6 +150,7 @@ so you may be able to disable one of the
 following: >
 
   let g:novim_mode_use_general_app_shortcuts = 1
+  let g:novim_mode_use_tab_shortcuts = 1
   let g:novim_mode_use_pane_controls = 1
   let g:novim_mode_use_copypasting = 1
   let g:novim_mode_use_indenting = 1

--- a/plugin/novim_mode.vim
+++ b/plugin/novim_mode.vim
@@ -9,6 +9,7 @@ set cpo&vim
 
 let s:settings = {
   \ 'use_general_app_shortcuts': 1,
+  \ 'use_tab_shortcuts': 1,
   \ 'use_editor_fixes': 1,
   \ 'use_pane_controls': 1,
   \ 'use_copypasting': 1,
@@ -40,7 +41,7 @@ call s:init_settings(s:settings)
 if has('timers') == 0
   echo "Novim-mode: Your Vim version (Vim <7.5 or Neovim <0.1.5) doesn't "
   echo "support `timer()`, which causes a bug where Insert Mode is "
-  echo "innapropriately set for some panes."
+  echo "inappropriately set for some panes."
 endif
 
 " Plugin entry point


### PR DESCRIPTION
This adds tab navigation functionality with the shortcuts `Ctrl+T` and `Ctrl+Shift+T`. `Ctrl+T` opens a new tab (empty file) and `Ctrl+Shift+T` cycles through open tabs. I don't think `Ctrl+T` and `Ctrl+Shift+T` conflict with any existing keybindings.

`Ctrl+Tab` and `Ctrl+Shift+Tab` unfortunately are reserved by the terminal emulator and aren't recognized by (Neo)Vim, otherwise I'd have loved to use them for `:tabnext` and `:tabprevious`.

Feel free to merge this or not, depending on if you're interested!